### PR TITLE
Fixed outdated json definition

### DIFF
--- a/l4w.go
+++ b/l4w.go
@@ -89,7 +89,7 @@ type CampaignResultStruct struct {
 	Location   string                 `json:"location"`
 	Date       time.Time              `json:"date"`
 	CampaignID string                 `json:"campaignId"`
-	Custom     map[string]string      `json:"custom"`
+	CustomData map[string]string      `json:"customData"`
 	Data       map[string]interface{} `json:"data"`
 	URL        string                 `json:"url"`
 	Time       float64                `json:"time"`


### PR DESCRIPTION
According to the Usabilla API documentation a campaign result looks like this:

```
{
  "id": "549972d5c469885e548b4570",
  "campaignId": "5499612ec4698839368b4573",
  "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.95 Safari/537.36",
  "location": "Amsterdam, Netherlands",
  "date": "2014-01-15T19:48:06.003Z",
  "customData": {
    "form_name": "form1"
  },
  "data": {
    "text": "test"
  },
  "time": 5000,
  "url": "https://usabilla.com"
}
```

However CampaignResultStruct had an outdated json definition and I fixed it.